### PR TITLE
Add optional accessibility statement URL to footer

### DIFF
--- a/frontend/views/site/_footer.html.erb
+++ b/frontend/views/site/_footer.html.erb
@@ -1,7 +1,7 @@
 <div class="container-fluid footer">
    <div class="row">
       <div class="col-md-12">
-        <p><a href='https://sites.google.com/a/umich.edu/bhl-archival-curation/processing-archival-collections' target='_blank'>BHL Processing Manual</a> | <% if AppConfig[:enable_public] %><%= t("footer.public_interface", :public_url => AppConfig[:public_proxy_url]) %> | <% end %><%= t("footer.archivesspace_home") %> | <%= ASConstants.VERSION %><% if AppConfig[:feedback_url] && !AppConfig[:feedback_url].blank? %> | <%= t("footer.feedback", :feedback_url => AppConfig[:feedback_url]) %> <% end %></p>
+        <p><a href='https://sites.google.com/a/umich.edu/bhl-archival-curation/processing-archival-collections' target='_blank'>BHL Processing Manual</a> | <% if AppConfig[:enable_public] %><%= t("footer.public_interface", :public_url => AppConfig[:public_proxy_url]) %> | <% end %><%= t("footer.archivesspace_home") %> | <%= ASConstants.VERSION %><% if AppConfig[:feedback_url] && !AppConfig[:feedback_url].blank? %> | <%= t("footer.feedback", :feedback_url => AppConfig[:feedback_url]) %> <% end %><% if AppConfig[:accessibility_statement_url] && !AppConfig[:accessibility_statement_url].blank? %> | <%= link_to "Accessibility", AppConfig[:accessibility_statement_url], target: "_blank" %> <% end %></p>
       </div>
    </div>
 </div>


### PR DESCRIPTION
This PR adds an optional "Accessibility" link to the footer of the homepage. It is turned on if the `:accessibility_statement_url` key is set in the `AppConfig` in `config.rb`. This helps us meet an organizational goal of having accessibility statements alongside our services.